### PR TITLE
Verify TLS connection

### DIFF
--- a/src/MaxCDN.php
+++ b/src/MaxCDN.php
@@ -52,7 +52,7 @@ class MaxCDN {
 		
 		//return the transfer as a string
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER , FALSE);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER , TRUE);
 		
 		// set curl timeout
 		curl_setopt($ch, CURLOPT_TIMEOUT, 60); 


### PR DESCRIPTION
Using TLS (SSL) without verifying the certificate on the remote end is insecure just like using plain HTTP.

I'm not sure why this was disabled in  the first place.