### PR TITLE
updated composer by PSR-0 convention

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,14 @@
     },
     "autoload": {
         "psr-0": {
-            "MaxCDN\\": "src/",
-            "": "src/"
-        }
+            "MaxCDN\\": "src/"
+        },
+        "classmap": [
+            "src/MaxCDN.php",
+            "src/MaxCDN/OAuth/OAuthSignatureMethod_PLAINTEXT.php",
+            "src/MaxCDN/OAuth/OAuthSignatureMethod_HMAC_SHA1.php",
+            "src/MaxCDN/OAuth/OAuthSignatureMethod_RSA_SHA1.php"
+        ]
     }
 
 }


### PR DESCRIPTION
Added classmap to bypass PSR-0 standard issue with underscores (_) - by PSR-0 underscores are translated into directory separators (slashes: /) whereas previous naming of files x_y_z will throw an exception.

Duplicates:
* https://github.com/MaxCDN/php-maxcdn/pull/8
* https://github.com/MaxCDN/php-maxcdn/issues/7