### PR TITLE
Added bracket to follow PSR-2

### DIFF
--- a/src/MaxCDN.php
+++ b/src/MaxCDN.php
@@ -28,7 +28,7 @@ class MaxCDN {
 
 	private function execute($selected_call, $method_type, $params) {
 		// the endpoint for your request
-		$endpoint = "$this->MaxCDNrws_url/$this->alias$selected_call"; 
+		$endpoint = "{$this->MaxCDNrws_url}/{$this->alias}{$selected_call}"; 
 		
 		//parse endpoint before creating OAuth request
 		$parsed = parse_url($endpoint);


### PR DESCRIPTION
In order to format the code based on PSR-2 standard I used phpfmt and it changed $endpoint = "$this->MaxCDNrws_url/$this->alias$selected_call"; to $endpoint = "$this->MaxCDNrws_url/$this->alias $selected_call"; (added space between $this->alias and $selected_call). To avoid it I used bracket. Also in the future we can format the entire code based on PSR-2