### PR TITLE
Fix fatal error

### DIFF
--- a/src/MaxCDN/OAuth/OAuthException.php
+++ b/src/MaxCDN/OAuth/OAuthException.php
@@ -4,7 +4,7 @@
  */
 namespace MaxCDN\OAuth;
 
-class OAuthException extends Exception {
+class OAuthException extends \Exception {
     // pass
 }
 


### PR DESCRIPTION
Fix fatal error "Class 'MaxCDN\OAuth\Exception' not found."