### PR TITLE
Fix string offset access syntax

### DIFF
--- a/src/MaxCDN/OAuth/OAuthSignatureMethod.php
+++ b/src/MaxCDN/OAuth/OAuthSignatureMethod.php
@@ -47,7 +47,7 @@ abstract class OAuthSignatureMethod {
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
         for ($i = 0; $i < strlen($signature); $i++) {
-            $result |= ord($built{$i}) ^ ord($signature{$i});
+            $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 
         return $result == 0;


### PR DESCRIPTION
PHP 7.4 shows the following fatal error.
```
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in vendor/maxcdn/php-maxcdn/src/MaxCDN/OAuth/OAuthSignatureMethod.php on line 50
```

This PR changes the access syntax to square brackets.